### PR TITLE
Use Component instead of PureComponent for StyledElement

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jss-preset-default": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^15.3.0"
+    "react": ">=14"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",

--- a/src/styled.js
+++ b/src/styled.js
@@ -1,4 +1,4 @@
-import {PureComponent, createElement} from 'react'
+import {Component, createElement} from 'react'
 import {getDynamicStyles} from 'jss'
 
 import filterProps from './utils/filterProps'
@@ -24,7 +24,7 @@ const styled = ({tagName, elementStyle, mountSheets}: StyledArgs) => {
 
   const availableDynamicTagNames = []
 
-  return class StyledElement extends PureComponent {
+  return class StyledElement extends Component {
     static tagName: string = tagName
     static style: ComponentStyleType = elementStyle
 


### PR DESCRIPTION
We decided to use `React.Component` instead of `React.PureComponent`.