### PR TITLE
Resolve #56, provide jss instance via styled

### DIFF
--- a/src/createStyled.js
+++ b/src/createStyled.js
@@ -28,7 +28,7 @@ const createStyled = (jss: Function) => (baseStyles: BaseStylesType = {}): Style
     get: () => sheet,
   }: Object)) // https://github.com/facebook/flow/issues/285
 
-  return Object.assign(styledWrapper, {mountSheet, styles: baseStyles})
+  return Object.assign(styledWrapper, {jss, mountSheet, styles: baseStyles})
 }
 
 export default createStyled


### PR DESCRIPTION
Now we can set `jss` plugins without the need to create special `styled` function.
For example:

```js
import styled from 'styled-jss'
import camelCase from 'jss-camel-case'

styled.jss.use(camelCase())
```

Note that it's better to set up all the plugins once somewhere in one place